### PR TITLE
feature/AAILM-540: Fixed Bugs Into The Plugin 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,5 +24,5 @@ runs:
         curl -X POST \
           -H "Authorization: Bearer ${{ inputs.token }}" \
           -H "Content-Type: application/hcl" \
-          -d "@$${{ inputs.job }}" \
-          "${{ inputs.deployment_url }}"
+          -d "@${{ inputs.job }}" \
+          "${{ inputs.endpoint}}"


### PR DESCRIPTION
Changes in this PR

This PR updates the Nomad deployment action to fix issues in the original nurdsoft/deploy-nomad@v0.3.1 action. The key differences are:





Variable Syntax:





- Original: Used -d "@$${{ inputs.job }}", causing curl to misinterpret the file path (e.g., as .nomad), resulting in the curl: Failed to open .nomad error.



- Corrected: Uses -d "@${{ inputs.job }}", correctly passing the job file path (e.g., deploy.nomad).



Endpoint Reference:





- Original: Referenced undefined ${{ inputs.deployment_url }}.



- Corrected: Uses ${{ inputs.endpoint }}, aligning with the defined endpoint input.

Impact: The corrected action resolves the file path error and ensures the correct endpoint is used, enabling successful Nomad job deployments.