### PR TITLE
feature: Set Nomad Variables 

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,12 +14,21 @@ inputs:
   endpoint:
     description: 'Endpoint to submit the job'
     required: true
+  environment:
+    description: 'Nomad environment variable value'
+    required: false
+  aws_account_id:
+    description: 'AWS Account ID'
+    required: false
 
 runs:
   using: "composite"
   steps:
     - name: Submit Job
       shell: bash
+      env:
+        NOMAD_VAR_environment: ${{ inputs.environment }}
+        NOMAD_VAR_aws_account_id: ${{ inputs.aws_account_id }}
       run: |
         curl -X POST \
           -H "X-API-Key: ${{ inputs.token }}" \

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,10 @@ inputs:
     description: 'Endpoint to submit the job'
     required: true
   environment:
-    description: 'Nomad environment variable value'
+    description: 'Nomad environment value'
     required: false
   aws_account_id:
-    description: 'AWS Account ID'
+    description: 'Nomad AWS Account ID value'
     required: false
 
 runs:


### PR DESCRIPTION
In this pull request (PR), I have added two new inputs: environment and aws_account_id. I marked both parameters as optional by setting their required attribute to false. Additionally, I exported them as NOMAD_VAR environment variables to ensure that Nomad HCL2 variables can be resolved during job submission.